### PR TITLE
Add note about broken Goal input in archi oprions creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ more information on [apworld](https://github.com/ArchipelagoMW/Archipelago/blob/
 ### Options yaml
 Pick and download a file from [sample-yamls](/sample-yamls/). Heavy editing to the sample is not encouraged unless you know what you're doing. More samples coming soon.
 
+### Important Note
+currently the Goal input input the Archipeligo options creator is broken and so you need to manually add it to your yaml the syntax is <br />Goal: '{your goal}' you can find the names of all the goals in the archi_defs.py file [here](https://github.com/EdricY/Bouncy-Loot-God/blob/main/sdk_mods/BouncyLootGod/archi_defs.py) they may not all work as this link if for the bleeding edge version but almost all of them will
+- you can find the files and therefore definitions for your specific version if you extract your bouncylootgod.sdkmod like a zip file
+
+
 ### Getting your multi world started
 1. Place player yaml file(s): Archipelago Client > Browse Files > Players > insert yaml files here.
 2. Generate world: Archipelago Client > Generate


### PR DESCRIPTION
Added an important note regarding the Goal input in the Archipelago options creator not working, including syntax and file location for goal definitions.