### PR TITLE
Raise Face Mc Shooty Level to level of required quests

### DIFF
--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -540,7 +540,7 @@ quest_data_table = {
     "Rock, Paper, Genocide: Shock Weapons!":                BL2ArchiData("Sanctuary", 7, req_items=["License: Uncommon Pistol"], is_non_gear_reward=True), # shock requirement
     "Animal Rescue: Medicine":                              BL2ArchiData("Lynchwood", 23, other_req_regions=["ThousandCuts", "WildlifeExploitationPreserve"], is_non_gear_reward=True),
     "Splinter Group":                                       BL2ArchiData("BloodshotStronghold", 13, associated_gear="Unique Shotgun", other_req_regions=["BloodshotRamparts", "FriendshipGulag"]),
-    "Shoot This Guy in the Face":                           BL2ArchiData("ThousandCuts", 1, is_non_gear_reward=True),
+    "Shoot This Guy in the Face":                           BL2ArchiData("ThousandCuts", 16, is_non_gear_reward=True),
     "Bandit Slaughter: Round 1":                            BL2ArchiData("FinksSlaughterhouse", 15, is_non_gear_reward=True),
     "Bandit Slaughter: Round 2":                            BL2ArchiData("FinksSlaughterhouse", 16, is_non_gear_reward=True),
     "Bandit Slaughter: Round 3":                            BL2ArchiData("FinksSlaughterhouse", 17, is_non_gear_reward=True),
@@ -811,7 +811,7 @@ loc_data_table = {
     "Enemy: Bloodwing":                              BL2ArchiData("WildlifeExploitationPreserve", 19),
     "Enemy: GOD-liath":                              BL2ArchiData("ThousandCuts", 20),
     "Enemy: Sarcastic Slab":                         BL2ArchiData("ThousandCuts", 20, other_req_regions=["WildlifeExploitationPreserve"]),
-    "Enemy: Face McShooty":                          BL2ArchiData("ThousandCuts", 1),
+    "Enemy: Face McShooty":                          BL2ArchiData("ThousandCuts", 16),
     "Enemy: Dukino's Mom":                           BL2ArchiData("Lynchwood", 25, other_req_regions=["ControlCoreAngel"]),
     "Enemy: Mad Dog":                                BL2ArchiData("Lynchwood", 23, other_req_regions=["ThousandCuts", "WildlifeExploitationPreserve"]),
     "Enemy: Sheriff Nisha":                          BL2ArchiData("Lynchwood", 25, other_req_regions=["ThousandCuts", "WildlifeExploitationPreserve"]),


### PR DESCRIPTION
Quest: Shoot This Guy In The Face needs a higher level requirement - current logic marks it as accessible with only Thousand Cuts access and melee or common pistol. 

Proposing about level 16, to match the level needed for Bright Lights, Flying City.

TY Swiftrunner