### PR TITLE
fixed requirements for Challange DahlAbandon: Cult Of The Vault

### DIFF
--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -1549,7 +1549,7 @@ loc_data_table = {
     "Challenge DahlAbandon: Mine, Dahl Mine!":                             BL2ArchiData("DahlAbandon", 30, other_req_regions=["HeliosFallen"], jump_z_req=382, tags=["reg-based"]),
     "Challenge DahlAbandon: Hold The Door!":                               BL2ArchiData("DahlAbandon", 30, other_req_regions=["HeliosFallen"], tags=["missable", "reg-based"]),
     "Challenge DahlAbandon: Out of Scope":                                 BL2ArchiData("DahlAbandon", 30, tags=["reg-based"]),
-    "Challenge DahlAbandon: Cult of the Vault":                            BL2ArchiData("DahlAbandon", 30, jump_z_req=415, tags=["reg-based"]),
+    "Challenge DahlAbandon: Cult of the Vault":                            BL2ArchiData("DahlAbandon", 30, other_req_regions=["HeliosFallen"], jump_z_req=415, tags=["reg-based"]),
     "Challenge MtScarab: For Science!":                                    BL2ArchiData("Mt.ScarabResearchCenter", 30, tags=["reg-based"]),
     "Challenge MtScarab: Gaseous Cassius":                                 BL2ArchiData("Mt.ScarabResearchCenter", 30, tags=["reg-based"]),
     "Challenge MtScarab: No Peeking":                                      BL2ArchiData("Mt.ScarabResearchCenter", 30, tags=["reg-based"]),


### PR DESCRIPTION
added Helios Fallen as a requirement for "Challange Dahl Abandon: Cult of The Vault" for "Symbol DahlAbandon: The Veiny Shaft"