### PR TITLE
implemented yamlless UT support

### DIFF
--- a/sample-yamls/tps-basegame.yaml
+++ b/sample-yamls/tps-basegame.yaml
@@ -31,7 +31,7 @@ Borderlands The Pre-Sequel:
   generic_mob_checks: 5_percent
   gear_rarity_checks: exclude_glitch
   challenge_checks: all
-  chest_checks: ['Dahl Chests', 'Red Chests', 'Moonstone Chests']
+  chest_type_checks: ['Dahl Chests', 'Red Chests', 'Moonstone Chests']
   remove_coop_checks: remove_all
   remove_missable_checks: remove
   remove_ffs_checks: keep

--- a/worlds/borderlands2/__init__.py
+++ b/worlds/borderlands2/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from BaseClasses import Item, ItemClassification, Region, Tutorial, LocationProgressType, MultiWorld
 from worlds.AutoWorld import WebWorld, World
@@ -10,6 +10,7 @@ from .Options import Borderlands2Options
 from .Regions import region_data_table, progressive_travel_dict, progressive_travel_items
 from .archi_defs import loc_name_to_id, item_id_to_name, gear_data_table, item_data_table, item_name_to_id as item_name_to_raw_id, BL2ArchiData
 import random
+from copy import deepcopy
 
 VERSION = "0.6.0"
 
@@ -172,20 +173,11 @@ class Borderlands2World(World):
 
         # TODO: maybe add regions beyond the goal to restricted regions, or we can just expect the yaml to add them to remove_specific_region_checks
 
-        # Implement Universal Tracker support - reset all options to those from UT's gen if applicable.
+        # Implement Universal Tracker support - reset all options to those from interpret_slot_data if applicable.
         if hasattr(self.multiworld, "re_gen_passthrough"):
             if bl2_name in self.multiworld.re_gen_passthrough:
-                loc_id_to_name = {v: k for k, v in location_name_to_id.items()}
-                
-                #the items here is the same as the state returned to AP, so we need to inverse any logic, 
-                # such as the remove_location and include_location mapping
-                # non mapped value properties can be mapped directly
                 for key, val in self.multiworld.re_gen_passthrough[bl2_name].items():
                     try:
-                        if key == "remove_locations":
-                            val = [loc_id_to_name[loc] for loc in val]
-                        elif key == "include_locations":
-                            val = [loc_id_to_name[loc] for loc in val]
                         getattr(self.options, key).value = val
                     except AttributeError:
                         pass
@@ -586,3 +578,12 @@ class Borderlands2World(World):
             "death_link_send_mode": self.options.death_link_send_mode.value,
         }
         return slot_data
+
+    @staticmethod
+    def interpret_slot_data(slot_data: dict[str, Any]) -> dict[str, Any]:
+        # Implement Universal Tracker support - interpret the computed fields back to their generator values
+        loc_id_to_name = {v: k for k, v in location_name_to_id.items()}
+        inversed_slot_data = deepcopy(slot_data)
+        inversed_slot_data["remove_locations"] = [loc_id_to_name[loc] for loc in slot_data["remove_locations"]]
+        inversed_slot_data["include_locations"] = [loc_id_to_name[loc] for loc in slot_data["include_locations"]]
+        return inversed_slot_data

--- a/worlds/borderlands2/__init__.py
+++ b/worlds/borderlands2/__init__.py
@@ -38,13 +38,18 @@ components.append(Component("Borderlands 2 Client",
                             component_type=Type.CLIENT))
 
 
+bl2_name = "Borderlands 2"
 class Borderlands2World(World):
     """
      Borderlands 2 is a looter shooter we all love.
     """
 
-    game = "Borderlands 2"
+    game = bl2_name
     web = Borderlands2WebWorld()
+
+    # UT Yaml-less flag
+    ut_can_gen_without_yaml = True
+    
     options_dataclass = Borderlands2Options
     options: Borderlands2Options
     location_name_to_id = location_name_to_id
@@ -166,6 +171,15 @@ class Borderlands2World(World):
         # self.options.exclude_locations.value.add(goal_name)
 
         # TODO: maybe add regions beyond the goal to restricted regions, or we can just expect the yaml to add them to remove_specific_region_checks
+
+        # Implement Universal Tracker support - reset all options to those from UT's gen if applicable.
+        if hasattr(self.multiworld, "re_gen_passthrough"):
+            if bl2_name in self.multiworld.re_gen_passthrough:
+                for key, val in self.multiworld.re_gen_passthrough[bl2_name].items():
+                    try:
+                        getattr(self.options, key).value = val
+                    except AttributeError:
+                        pass
 
     def is_gear_license_excluded(self, name: str) -> bool:
         if self.options.gear_licenses.value <= 3 and name.startswith("License: Rainbow"):

--- a/worlds/borderlands2/__init__.py
+++ b/worlds/borderlands2/__init__.py
@@ -175,8 +175,17 @@ class Borderlands2World(World):
         # Implement Universal Tracker support - reset all options to those from UT's gen if applicable.
         if hasattr(self.multiworld, "re_gen_passthrough"):
             if bl2_name in self.multiworld.re_gen_passthrough:
+                loc_id_to_name = {v: k for k, v in location_name_to_id.items()}
+                
+                #the items here is the same as the state returned to AP, so we need to inverse any logic, 
+                # such as the remove_location and include_location mapping
+                # non mapped value properties can be mapped directly
                 for key, val in self.multiworld.re_gen_passthrough[bl2_name].items():
                     try:
+                        if key == "remove_locations":
+                            val = [loc_id_to_name[loc] for loc in val]
+                        elif key == "include_locations":
+                            val = [loc_id_to_name[loc] for loc in val]
                         getattr(self.options, key).value = val
                     except AttributeError:
                         pass

--- a/worlds/borderlands_tps/Options.py
+++ b/worlds/borderlands_tps/Options.py
@@ -368,8 +368,8 @@ class ChallengeChecks(Choice):
 
     default = 1
 
-# chest_checks
-class ChestChecks(OptionSet):
+# chest_type_checks
+class ChestTypeChecks(OptionSet):
     """
     Adds checks for opening Chests
     Dahl Chests: The blue wide chests with "Dahl" on their side
@@ -654,7 +654,7 @@ class BorderlandsTPSOptions(PerGameCommonOptions):
     generic_mob_checks: GenericMobChecks
     gear_rarity_checks: GearRarityChecks
     challenge_checks: ChallengeChecks
-    chest_checks: ChestChecks
+    chest_type_checks: ChestTypeChecks
     start_with_melee: StartWithMelee
     remove_coop_checks: RemoveCoopChecks
     remove_missable_checks: RemoveMissableChecks

--- a/worlds/borderlands_tps/__init__.py
+++ b/worlds/borderlands_tps/__init__.py
@@ -42,14 +42,19 @@ components.append(Component("Borderlands The Pre-Sequel Client",
                             func=launch_client,
                             component_type=Type.CLIENT))
 
-
+bl_tps_name = "Borderlands The Pre-Sequel"
 class BorderlandsTPSWorld(World):
     """
      Borderlands The Pre-Sequel is a looter shooter we all love.
     """
+    
 
-    game = "Borderlands The Pre-Sequel"
+    game = bl_tps_name
     web = BorderlandsTPSWebWorld()
+    
+    # UT Yaml-less flag
+    ut_can_gen_without_yaml = True
+    
     options_dataclass = BorderlandsTPSOptions
     options: BorderlandsTPSOptions
     location_name_to_id = location_name_to_id
@@ -163,6 +168,20 @@ class BorderlandsTPSWorld(World):
         # self.options.exclude_locations.value.add(goal_name)
 
         # TODO: maybe add regions beyond the goal to restricted regions, or we can just expect the yaml to add them to remove_specific_region_checks
+        # Implement Universal Tracker support - reset all options to those from UT's gen if applicable.
+        if hasattr(self.multiworld, "re_gen_passthrough"):
+            if bl_tps_name in self.multiworld.re_gen_passthrough:
+                for key, val in self.multiworld.re_gen_passthrough[bl_tps_name].items():
+                    #TPS has multiple chest types, so the setting is named differently
+                    # TODO: rename the chest_check option to be chest_type_checks
+                    if key == "chest_checks":
+                        continue
+                    if key == "chest_type_checks":
+                        key = "chest_checks"
+                    try:
+                        getattr(self.options, key).value = val
+                    except AttributeError:
+                        pass
 
     def is_gear_license_excluded(self, name: str) -> bool:
         if self.options.gear_licenses.value <= 1 and name.startswith("License: Glitch"):

--- a/worlds/borderlands_tps/__init__.py
+++ b/worlds/borderlands_tps/__init__.py
@@ -171,6 +171,11 @@ class BorderlandsTPSWorld(World):
         # Implement Universal Tracker support - reset all options to those from UT's gen if applicable.
         if hasattr(self.multiworld, "re_gen_passthrough"):
             if bl_tps_name in self.multiworld.re_gen_passthrough:
+                loc_id_to_name = {v: k for k, v in location_name_to_id.items()}
+                chest_check_prefix_to_option = {v: k for k, v in chest_check_option_to_prefix.items()}
+                #the items here is the same as the state returned to AP, so we need to inverse any logic, 
+                # such as the remove_location and include_location mapping
+                # non mapped value properties can be mapped directly
                 for key, val in self.multiworld.re_gen_passthrough[bl_tps_name].items():
                     #TPS has multiple chest types, so the setting is named differently
                     # TODO: rename the chest_check option to be chest_type_checks
@@ -178,7 +183,12 @@ class BorderlandsTPSWorld(World):
                         continue
                     if key == "chest_type_checks":
                         key = "chest_checks"
+                        val = [chest_check_prefix_to_option[prefix] for prefix in val]
                     try:
+                        if key == "remove_locations":
+                            val = [loc_id_to_name[loc] for loc in val]
+                        elif key == "include_locations":
+                            val = [loc_id_to_name[loc] for loc in val]
                         getattr(self.options, key).value = val
                     except AttributeError:
                         pass

--- a/worlds/borderlands_tps/__init__.py
+++ b/worlds/borderlands_tps/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from BaseClasses import Item, ItemClassification, Region, Tutorial, LocationProgressType, MultiWorld
 from worlds.AutoWorld import WebWorld, World
@@ -10,6 +10,7 @@ from .Options import BorderlandsTPSOptions
 from .Regions import region_data_table, progressive_travel_dict, progressive_travel_items
 from .archi_defs import loc_name_to_id, item_id_to_name, gear_data_table, item_data_table, item_name_to_id as item_name_to_raw_id
 import random
+from copy import deepcopy
 
 VERSION = "0.6.0"
 
@@ -168,27 +169,11 @@ class BorderlandsTPSWorld(World):
         # self.options.exclude_locations.value.add(goal_name)
 
         # TODO: maybe add regions beyond the goal to restricted regions, or we can just expect the yaml to add them to remove_specific_region_checks
-        # Implement Universal Tracker support - reset all options to those from UT's gen if applicable.
+        # Implement Universal Tracker support - reset all options to those from interpret_slot_data if applicable.
         if hasattr(self.multiworld, "re_gen_passthrough"):
             if bl_tps_name in self.multiworld.re_gen_passthrough:
-                loc_id_to_name = {v: k for k, v in location_name_to_id.items()}
-                chest_check_prefix_to_option = {v: k for k, v in chest_check_option_to_prefix.items()}
-                #the items here is the same as the state returned to AP, so we need to inverse any logic, 
-                # such as the remove_location and include_location mapping
-                # non mapped value properties can be mapped directly
                 for key, val in self.multiworld.re_gen_passthrough[bl_tps_name].items():
-                    #TPS has multiple chest types, so the setting is named differently
-                    # TODO: rename the chest_check option to be chest_type_checks
-                    if key == "chest_checks":
-                        continue
-                    if key == "chest_type_checks":
-                        key = "chest_checks"
-                        val = [chest_check_prefix_to_option[prefix] for prefix in val]
                     try:
-                        if key == "remove_locations":
-                            val = [loc_id_to_name[loc] for loc in val]
-                        elif key == "include_locations":
-                            val = [loc_id_to_name[loc] for loc in val]
                         getattr(self.options, key).value = val
                     except AttributeError:
                         pass
@@ -411,8 +396,8 @@ class BorderlandsTPSWorld(World):
                         loc_dict[location_name] = None
 
             # remove chest checks
-            for opt in self.options.chest_checks.valid_keys:
-                if opt not in self.options.chest_checks.value:
+            for opt in self.options.chest_type_checks.valid_keys:
+                if opt not in self.options.chest_type_checks.value:
                     if location_name.startswith(chest_check_option_to_prefix[opt]):
                         loc_dict[location_name] = None
 
@@ -557,8 +542,8 @@ class BorderlandsTPSWorld(World):
             #"named_enemy_checks": self.options.named_enemy_checks.value, Placeholder for when option gets added
             "gear_rarity_checks": self.options.gear_rarity_checks.value,
             "challenge_checks": self.options.challenge_checks.value,
-            "chest_checks": min(1, len(self.options.chest_checks.value)), #enable chest checks if there is any
-            "chest_type_checks": [chest_check_option_to_prefix[chest_check] for chest_check in self.options.chest_checks.value],
+            "chest_checks": min(1, len(self.options.chest_type_checks.value)), #enable chest checks if there is any
+            "chest_type_checks": [chest_check_option_to_prefix[chest_check] for chest_check in self.options.chest_type_checks.value],
             "remove_missable_checks": self.options.remove_missable_checks.value,
             "remove_coop_checks": self.options.remove_coop_checks.value,
             "remove_claptrap_checks": self.options.remove_claptrap_checks.value,
@@ -577,3 +562,15 @@ class BorderlandsTPSWorld(World):
             "death_link_send_mode": self.options.death_link_send_mode.value,
         }
         return slot_data
+
+    @staticmethod
+    def interpret_slot_data(slot_data: dict[str, Any]) -> dict[str, Any]:
+        # Implement Universal Tracker support - interpret the computed fields back to their generator values
+        loc_id_to_name = {v: k for k, v in location_name_to_id.items()}
+        chest_check_prefix_to_option = {v: k for k, v in chest_check_option_to_prefix.items()}
+        inversed_slot_data = deepcopy(slot_data)
+        #all fields that cant be directly applied to generator options needs to be handled here
+        inversed_slot_data["chest_type_checks"] = [chest_check_prefix_to_option[prefix] for prefix in slot_data["chest_type_checks"]]
+        inversed_slot_data["remove_locations"] = [loc_id_to_name[loc] for loc in slot_data["remove_locations"]]
+        inversed_slot_data["include_locations"] = [loc_id_to_name[loc] for loc in slot_data["include_locations"]]
+        return inversed_slot_data


### PR DESCRIPTION
**Added**
 - support for yamlless UT tracker
 
---
**TESTING**
- generated and then removed yamls from Player folder, then opened client(s)
- generated with and without remove_locations
- generated with and without include_locations
- sent required items to progress, License: Common Pistol for BL2, Travel: Serenity's Waste for TPS
Tracker responded as expected