### PR TITLE
add Winged Storm jump requirement

### DIFF
--- a/worlds/borderlands2/Rules.py
+++ b/worlds/borderlands2/Rules.py
@@ -219,6 +219,8 @@ def set_world_rules(world: Borderlands2World):
             lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 490))) # jumping out of "kicked out" area, final cookie vending machine, barrier into Badassasaurus fight
         try_add_rule(world.try_get_entrance("HerosPass to VaultOfTheWarrior"),
             lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 575))) # needed to jump over the broken bridge
+        try_add_rule(world.try_get_entrance("LairOfInfiniteAgony to WingedStorm"),
+            lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 425))) # need to complete Fake Geek Guy
 
     # TODO: these events should be removed/skipped if inaccesssible. Could move to archi_defs file, or maybe recreated as rules in a Rule Builder refactor
     # detecting end of Torgue DLC is a little weird.


### PR DESCRIPTION
Raiders of the Last Boss cannot be started until Fake Geek Guy is completed.  Winged Storm cannot be entered until Raiders of the Last Boss is started.  Therefore, Winged Storm requires the 425 jump height check of Fake Geek Guy to enter.