### PR TITLE
Added an override for Generic Enemy Drops

### DIFF
--- a/sdk_mods/BouncyLootGod/__init__.py
+++ b/sdk_mods/BouncyLootGod/__init__.py
@@ -1686,7 +1686,7 @@ oid_jump_z_downscale: SliderOption = SliderOption(
 )
 
 oid_sprint_downscale: SliderOption = SliderOption(
-    identifier="sprint percent",
+    identifier="Sprint Percent",
     value=100,
     min_value=0,
     max_value=100,

--- a/sdk_mods/BouncyLootGod/__init__.py
+++ b/sdk_mods/BouncyLootGod/__init__.py
@@ -51,7 +51,7 @@ else:
     from BouncyLootGod.challenges import challenge_dict, reveal_annoying_challenges
     from BouncyLootGod.chests import chest_dict
     socket_port = 9997
-from BouncyLootGod.enemies import enemy_class_to_loc_name
+from BouncyLootGod.enemies import enemy_class_to_loc_name, oid_generic_drop_chance_override
 from BouncyLootGod.vending import vending_machine_position_to_name, use_vending_machine
 from BouncyLootGod.archi_data import item_name_to_id, item_id_to_name, loc_name_to_id
 from BouncyLootGod.missions import grant_mission_reward, mission_ue_str_to_name, move_southern_shelf_blocked_missions
@@ -1653,7 +1653,7 @@ def log_to_file(line):
         return
 
 oid_jump_z_override: SliderOption = SliderOption(
-    identifier="jump z (debug)",
+    identifier="Jump Z (Debug)",
     value=0,
     min_value=0,
     max_value=2000,
@@ -1663,7 +1663,7 @@ oid_jump_z_override: SliderOption = SliderOption(
 )
 
 oid_sprint_override: SliderOption = SliderOption(
-    identifier="sprint (debug)",
+    identifier="Sprint (Debug)",
     value=0,
     min_value=0,
     max_value=4,
@@ -1675,7 +1675,7 @@ oid_sprint_override: SliderOption = SliderOption(
 
 
 oid_jump_z_downscale: SliderOption = SliderOption(
-    identifier="jump percent",
+    identifier="Jump Percent",
     value=100,
     min_value=0,
     max_value=100,
@@ -1695,6 +1695,19 @@ oid_sprint_downscale: SliderOption = SliderOption(
         "Scale your sprint speed down if your unlocked amount is too high. Set to 100 for full unlocked amount."
     )
 )
+
+# Is initialized in enemies.py and imported
+#
+# oid_generic_drop_chance_override: SliderOption = SliderOption(
+#     identifier="Generic Drop Chance",
+#     value=0,
+#     min_value=0,
+#     max_value=100,
+#     step=1,
+#     description=(
+#         "Override your current drop chance for Generic Item Drops. Set to 0 for your default set chance."
+#     )
+# )
 
 @hook("WillowGame.SkillTreeGFxObject:CanUpgradeSkill")
 def can_upgrade_skill(obj: unreal.UObject, args: unreal.WrappedStruct, ret, func: unreal.BoundFunction):
@@ -1781,6 +1794,7 @@ mod_instance = build_mod(
         oid_sprint_override,
         oid_jump_z_downscale,
         oid_sprint_downscale,
+        oid_generic_drop_chance_override,
     ],
     on_enable=on_enable,
     on_disable=on_disable,

--- a/sdk_mods/BouncyLootGod/enemies.py
+++ b/sdk_mods/BouncyLootGod/enemies.py
@@ -1,6 +1,6 @@
 
 import unrealsdk
-from mods_base import Game
+from mods_base import Game, SliderOption
 from BouncyLootGod.state import get_globals, ApItemMesh
 from BouncyLootGod.archi_data import loc_name_to_id
 from BouncyLootGod.traps import is_trap_pawn_def
@@ -114,7 +114,10 @@ def setup_generic_mob_drops():
     all_pawns = unrealsdk.find_all("AIPawnBalanceDefinition")
     all_pawns = [p for p in all_pawns if not is_trap_pawn_def(p)]
 
-    chance = blg.settings.get("generic_mob_checks", 5) * 0.01
+    if oid_generic_drop_chance_override.value != 0:
+        chance = oid_generic_drop_chance_override.value
+    else:
+        chance = blg.settings.get("generic_mob_checks", 5) * 0.01
     # chance = 1
 
     for pawn in all_pawns:
@@ -128,3 +131,14 @@ def setup_generic_mob_drops():
                     continue
                 # print(f"{search_str} {pawn_str}")
                 setup_check_drop(generic_enemy, pawn, chance=chance)
+
+oid_generic_drop_chance_override: SliderOption = SliderOption(
+    identifier="Generic Drop Chance",
+    value=0,
+    min_value=0,
+    max_value=100,
+    step=1,
+    description=(
+        "Override your current drop chance for Generic Item Drops. Set to 0 for your default set chance."
+    )
+)

--- a/sdk_mods/BouncyLootGod/enemies.py
+++ b/sdk_mods/BouncyLootGod/enemies.py
@@ -133,7 +133,7 @@ def setup_generic_mob_drops():
                 setup_check_drop(generic_enemy, pawn, chance=chance)
 
 oid_generic_drop_chance_override: SliderOption = SliderOption(
-    identifier="Generic Drop Chance",
+    identifier="Generic Drop Chance (Debug)",
     value=0,
     min_value=0,
     max_value=100,

--- a/sdk_mods/BouncyLootGod/enemies.py
+++ b/sdk_mods/BouncyLootGod/enemies.py
@@ -115,7 +115,7 @@ def setup_generic_mob_drops():
     all_pawns = [p for p in all_pawns if not is_trap_pawn_def(p)]
 
     if oid_generic_drop_chance_override.value != 0:
-        chance = oid_generic_drop_chance_override.value
+        chance = oid_generic_drop_chance_override.value / 100
     else:
         chance = blg.settings.get("generic_mob_checks", 5) * 0.01
     # chance = 1

--- a/sdk_mods/BouncyLootGod/enemies.py
+++ b/sdk_mods/BouncyLootGod/enemies.py
@@ -71,12 +71,12 @@ def create_pizza_item_pool(check_name):
     item_pool.BalancedItems[0].InvBalanceDefinition = inv
     return item_pool
 
-def setup_check_drop(check_name, ai_pawn_bd=None, behavior_spawn_items=None, chance=1.0):
+def setup_check_drop(check_name, ai_pawn_bd=None, behavior_spawn_items=None, chance=1.0, skip_already_checked=True):
     if not ai_pawn_bd and not behavior_spawn_items:
         print("don't know where to put check: " + check_name)
         return
     blg = get_globals()
-    if loc_name_to_id[check_name] in blg.locations_checked:
+    if loc_name_to_id[check_name] in blg.locations_checked and skip_already_checked:
         return
 
     item_pool = create_pizza_item_pool(check_name)
@@ -108,15 +108,18 @@ def setup_check_drop(check_name, ai_pawn_bd=None, behavior_spawn_items=None, cha
 
 def setup_generic_mob_drops():
     blg = get_globals()
-    if blg.settings.get("generic_mob_checks", 0) == 0:
-        return
+    
+    skip_already_checked=True
 
     all_pawns = unrealsdk.find_all("AIPawnBalanceDefinition")
     all_pawns = [p for p in all_pawns if not is_trap_pawn_def(p)]
 
     if oid_generic_drop_chance_override.value != 0:
         chance = oid_generic_drop_chance_override.value / 100
+        skip_already_checked=False
     else:
+        if blg.settings.get("generic_mob_checks", 0) == 0:
+            return
         chance = blg.settings.get("generic_mob_checks", 5) * 0.01
     # chance = 1
 
@@ -130,7 +133,7 @@ def setup_generic_mob_drops():
                 if generic_enemy == "Generic: Thresher" and "tentacle" in pawn_str:
                     continue
                 # print(f"{search_str} {pawn_str}")
-                setup_check_drop(generic_enemy, pawn, chance=chance)
+                setup_check_drop(generic_enemy, pawn, chance=chance, skip_already_checked=skip_already_checked)
 
 oid_generic_drop_chance_override: SliderOption = SliderOption(
     identifier="Generic Drop Chance (Debug)",
@@ -139,6 +142,6 @@ oid_generic_drop_chance_override: SliderOption = SliderOption(
     max_value=100,
     step=1,
     description=(
-        "Override your current drop chance for Generic Item Drops. Set to 0 for your default set chance."
+        "Override your current drop chance for Generic Item Drops. After changing the drop chance, either save quit and reload or move to a new area to enable the new drop chance. Set to 0 for your default set chance."
     )
 )


### PR DESCRIPTION
Added a new menu option to override the drop chance for generic enemy drops. If it is set to 0, it is ignored, else it is overwritten by the value 1-100.

Tested it by generating a world with 10% drop chance and killing the bullymongs in Windshear with and without the option set to 100. Worked as expected.

TY @Wolf-Hydra for the help