### PR TITLE
Buzzard Factory chest logic fix

### DIFF
--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -1954,7 +1954,7 @@ loc_data_table = {
     "Chest AridNexusBoneyard: Eridium Pump Station 3":              BL2ArchiData("AridNexusBoneyard", 26, jump_z_req=630), # 640?
     "Chest WindshearWaste: Blindsided":                             BL2ArchiData("WindshearWaste", 1),
     "Chest ThousandCuts: Slab UHF":                                 BL2ArchiData("ThousandCuts", 20, jump_z_req=630), # maybe hard with just 630
-    "Chest ThousandCuts: Buzzard Factory":                          BL2ArchiData("ThousandCuts", 20),
+    "Chest ThousandCuts: Buzzard Factory":                          BL2ArchiData("ThousandCuts", 20, other_req_regions=["WildlifeExploitationPreserve"]),
     "Chest ThousandCuts: Control Core Loading Dock":                BL2ArchiData("ThousandCuts", 21, other_req_regions=["WildlifeExploitationPreserve", "Opportunity"]),
     "Chest ThousandCuts: Super Badass Constructor":                 BL2ArchiData("ThousandCuts", 21, other_req_regions=["WildlifeExploitationPreserve", "Opportunity"]),
     "Chest Lynchwood: MadDog Trunk":                                BL2ArchiData("Lynchwood", 19),


### PR DESCRIPTION
Chest ThousandCuts: Buzzard Factory cannot be obtained until after going through Wildlife Exploitation Preserve - it is inside the buzzard factory building, which cannot be entered until then.