### PR TITLE
Benny the Booster logic fix

### DIFF
--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -876,7 +876,7 @@ loc_data_table = {
     "Enemy: Grendel":                                  BL2ArchiData("HaytersFolly", 15),
     "Enemy: Sandman":                                  BL2ArchiData("HaytersFolly", 15),
     "Enemy: Big Sleep":                                BL2ArchiData("HaytersFolly", 15),
-    "Enemy: Benny the Booster":                        BL2ArchiData("Oasis", 15, other_req_regions=["Rustyards"]),
+    "Enemy: Benny the Booster":                        BL2ArchiData("Oasis", 15, other_req_regions=["HaytersFolly"]),
     "Enemy: Deckhand":                                 BL2ArchiData("HaytersFolly", 15),
     "Enemy: Toothless Terry":                          BL2ArchiData("Rustyards", 15),
     "Enemy: P3RV-E":                                   BL2ArchiData("WashburneRefinery", 15),


### PR DESCRIPTION
Benny the Booster does not require entering Rustyards to make spawn, only Hayter's Folly.  Logic adjusted accordingly.