### PR TITLE
FFS Boss Fight jump dependency fix

### DIFF
--- a/worlds/borderlands2/Rules.py
+++ b/worlds/borderlands2/Rules.py
@@ -219,6 +219,8 @@ def set_world_rules(world: Borderlands2World):
             lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 490))) # jumping out of "kicked out" area, final cookie vending machine, barrier into Badassasaurus fight
         try_add_rule(world.try_get_entrance("HerosPass to VaultOfTheWarrior"),
             lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 575))) # needed to jump over the broken bridge
+        try_add_rule(world.try_get_entrance("Mt.ScarabResearchCenter to FFSBossFight"),
+            lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 588))) # Almost everything that requires FFS Boss Fight requires completing Paradise Found, which needs 588 jump.  
         try_add_rule(world.try_get_entrance("LairOfInfiniteAgony to WingedStorm"),
             lambda state: state.has("Progressive Jump", world.player, amt_jump_checks_needed(world, 425))) # need to complete Fake Geek Guy
         try_add_rule(world.try_get_entrance("BadassCrater to SouthernRaceway"),

--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -576,7 +576,7 @@ quest_data_table = {
     "A Hard Place":                                         BL2ArchiData("Burrows", 30, is_non_gear_reward=True, tags=["story"]),
     "Shooting The Moon":                                    BL2ArchiData("HeliosFallen", 30, is_non_gear_reward=True, tags=["story"]),
     "The Cost of Progress":                                 BL2ArchiData("Mt.ScarabResearchCenter", 30, is_non_gear_reward=True, tags=["story"]),
-    "Paradise Found":                                       BL2ArchiData("FFSBossFight", 30, associated_gear="Rainbow Relic", jump_z_req=588, tags=["story"]),
+    "Paradise Found":                                       BL2ArchiData("FFSBossFight", 30, associated_gear="Rainbow Relic", tags=["story"]),
     "Claptocurrency":                                       BL2ArchiData("DahlAbandon", 30, other_req_regions=["HeliosFallen"], is_non_gear_reward=True, jump_z_req=380),
     "BFFFs":                                                BL2ArchiData("Mt.ScarabResearchCenter", 30, other_req_regions=["FFSBossFight"], jump_z_req=400, associated_gear="Legendary SniperRifle"),
     "Hypocritical Oath":                                    BL2ArchiData("DahlAbandon", 30, is_non_gear_reward=True),


### PR DESCRIPTION
Other than the two exceptions of killing Hector and completing the "Timber!" challenge, every single check and region that requires access to FFS Boss Fight requires completing Paradise Found.  Completing Paradise Found requires completing a 588 height jump.  Therefore, in line with a similar decision regarding Terminus's many many many crouch requirements, adding rule that FFS Boss Fight access just requires 588 jump.  Jump requirement on Paradise Found also removed, as it would now be redundant.