### PR TITLE
Enemy and level check settings, stuff from mopioid suggestions

### DIFF
--- a/sdk_mods/BouncyLootGod/__init__.py
+++ b/sdk_mods/BouncyLootGod/__init__.py
@@ -397,7 +397,8 @@ def init_data():
     if not seed:
         show_chat_message("No seed detected!")
         seed = "blah"
-    blg.items_filepath = os.path.join(storage_dir, seed + ".items.txt")
+    filename = f"{blg.settings.get("slot", "")}_{seed}.items.txt"
+    blg.items_filepath = os.path.join(storage_dir, filename)
     pull_locations()
     blg.should_do_initial_modify = True
     if len(blg.locations_checked) == 0 and not os.path.exists(blg.items_filepath):

--- a/sdk_mods/BouncyLootGod/state.py
+++ b/sdk_mods/BouncyLootGod/state.py
@@ -8,6 +8,15 @@ from ui_utils import show_chat_message
 from dataclasses import dataclass
 from typing import Callable
 
+def game_is_bl1():
+    return Game.get_tree() == Game.Willow1
+
+def game_is_bl2():
+    return Game.get_current() == Game.BL2
+
+def game_is_tps():
+    return Game.get_current() == Game.TPS
+
 @dataclass
 class ApItemMesh:
     item_definition: str
@@ -146,7 +155,7 @@ class BLGGlobals:
 def init_globals():
     global blg
     blg = BLGGlobals()
-    if Game.get_current().name == "TPS":
+    if game_is_tps():
         blg.drop_item_mesh = ApItemMesh(
             item_definition="GD_DefaultProfiles.IntroEchos.BD_PrototypeIntroEcho",
             usable_item_definition="GD_Baroness_Items_crocus.Baroness.Head_Baron002",

--- a/worlds/borderlands2/Client.py
+++ b/worlds/borderlands2/Client.py
@@ -68,6 +68,7 @@ class Borderlands2Context(SuperContext):
 
         if cmd == 'Connected':
             self.slot_data = args.get("slot_data", {})
+            self.slot_data["slot"] = self.player_names.get(self.slot, "")
         elif cmd == "RoomInfo":
             self.seed_name = args['seed_name']
 
@@ -103,6 +104,7 @@ async def main(launch_args):
                     # check for goal completion
                     if msg["loc"] in ctx.slot_data["goals"]:
                         goal_completed_count = 1
+                        # msg was one of the goals, check if all other goals are done
                         for goal in ctx.slot_data["goals"]:
                             if goal == msg["loc"]:
                                 continue

--- a/worlds/borderlands2/Options.py
+++ b/worlds/borderlands2/Options.py
@@ -137,7 +137,11 @@ class FillerItemRotation(OptionList):
 
 # vault_symbols
 class VaultSymbols(Choice):
-    """Vault Symbols as location checks"""
+    """Vault Symbols as location checks
+    none = No vault symbols are checks. Cult of the Vault challenges are also removed.
+    all = All vault symbols are checks. Cult of the Vault challenges are handled by "challenge_checks".
+    remove_symbols = Individual vault symbols are removed as checks. Cult of the Vault challenges are handled by "challenge_checks".
+    """
     display_name = "Vault Symbols"
     option_none = 0
     alias_remove = 0
@@ -148,6 +152,9 @@ class VaultSymbols(Choice):
     alias_keep = 1
     alias_on = 1
     alias_true = 1
+    option_remove_symbols = 2
+    alias_symbols_remove = 2
+    alias_remove_individual = 2
     default = 1
 
 # vending_machines

--- a/worlds/borderlands2/Options.py
+++ b/worlds/borderlands2/Options.py
@@ -134,6 +134,39 @@ class FillerItemRotation(OptionList):
     valid_keys = [k for k, v in item_data_table.items() if v.item_kind in ("filler", "trap")] + ["gear", "sdu"]
     default = ["RandomCandy", "gear", "sdu", "3 Skill Points", "$100", "10 Eridium", "10% Exp"]
 
+# level_up_checks
+class LevelUpChecks(Choice):
+    """Adds checks into the location pool for leveling up (level 2 through 30)
+    Level Ups are removed/skipped when using "Override Level 15" or "Override Level 30"
+    """
+    display_name = "Level Up Checks"
+    option_none = 0
+    alias_remove = 0
+    alias_remove_all = 0
+    alias_off = 0
+    alias_false = 0
+    option_all = 1
+    alias_keep = 1
+    alias_on = 1
+    alias_true = 1
+    default = 1
+
+# named_enemy_checks
+class NamedEnemyChecks(Choice):
+    """Adds checks into the location pool for killing named enemies
+    """
+    display_name = "Named Enemy Checks"
+    option_none = 0
+    alias_remove = 0
+    alias_remove_all = 0
+    alias_off = 0
+    alias_false = 0
+    option_all = 1
+    alias_keep = 1
+    alias_on = 1
+    alias_true = 1
+    # TODO: add setting for optional enemies only
+    default = 1
 
 # vault_symbols
 class VaultSymbols(Choice):
@@ -369,14 +402,6 @@ class GenericMobChecks(Choice):
     option_10_percent = 10
     default = 5
 
-# TODO: add this option
-# class NamedEnemyChecks(Choice):
-#     """Adds checks into the location pool for killing each named enemies
-#     """
-#     display_name = "Named Enemy Checks"
-#     option_none = 0
-#     option_all = 1
-#     default = 1
 
 # gear_rarity_checks
 class GearRarityChecks(Choice):
@@ -746,6 +771,8 @@ class Borderlands2Options(PerGameCommonOptions):
     receive_gear: ReceiveGearItems
     filler_gear: FillerGear
     filler_item_rotation: FillerItemRotation
+    level_up_checks: LevelUpChecks
+    named_enemy_checks: NamedEnemyChecks
     vault_symbols: VaultSymbols
     vending_machines: VendingMachines
     entrance_locks: EntranceLocks

--- a/worlds/borderlands2/__init__.py
+++ b/worlds/borderlands2/__init__.py
@@ -392,6 +392,12 @@ class Borderlands2World(World):
             if location_name in self.options.include_locations.value:
                 return True
 
+        if self.options.named_enemy_checks.value == 0 and location_name.startswith("Enemy:"):
+            return False
+
+        if self.options.level_up_checks.value == 0 and location_name.startswith("Level "):
+            return False
+
         # remove symbols
         if self.options.vault_symbols.value in (0, 2):
             if location_name.startswith("Symbol"):
@@ -568,6 +574,8 @@ class Borderlands2World(World):
             "gear_licenses": self.options.gear_licenses.value,
             "filler_gear": self.options.filler_gear.value,
             "receive_gear": self.options.receive_gear.value,
+            "named_enemy_checks": self.options.named_enemy_checks.value,
+            "level_up_checks": self.options.level_up_checks.value,
             "vault_symbols": self.options.vault_symbols.value,
             "vending_machines": self.options.vending_machines.value,
             "entrance_locks": self.options.entrance_locks.value,
@@ -581,7 +589,6 @@ class Borderlands2World(World):
             "quest_completion_checks": self.options.quest_completion_checks.value,
             "quest_reward_items": self.options.quest_reward_items.value,
             "generic_mob_checks": self.options.generic_mob_checks.value,
-            #"named_enemy_checks": self.options.named_enemy_checks.value, Placeholder for when option gets added
             "gear_rarity_checks": self.options.gear_rarity_checks.value,
             "challenge_checks": self.options.challenge_checks.value,
             "chest_checks": self.options.chest_checks.value,

--- a/worlds/borderlands2/__init__.py
+++ b/worlds/borderlands2/__init__.py
@@ -393,10 +393,10 @@ class Borderlands2World(World):
                 return True
 
         # remove symbols
-        if self.options.vault_symbols.value == 0:
+        if self.options.vault_symbols.value in (0, 2):
             if location_name.startswith("Symbol"):
                 return False
-            if location_name.endswith("Cult of the Vault"):
+            if self.options.vault_symbols.value == 0 and location_name.endswith("Cult of the Vault"):
                 return False
 
         # remove vending machines

--- a/worlds/borderlands_tps/Client.py
+++ b/worlds/borderlands_tps/Client.py
@@ -68,6 +68,7 @@ class BorderlandsTPSContext(SuperContext):
         
         if cmd == 'Connected':
             self.slot_data = args.get("slot_data", {})
+            self.slot_data["slot"] = self.player_names.get(self.slot, "")
         elif cmd == "RoomInfo":
             self.seed_name = args['seed_name']
 


### PR DESCRIPTION
- new setting to remove symbols without removing cult of the vault challenges
- named enemy locations toggleable
- level up checks toggleable (need more options for this in the future)
- slot name + seed for .items.txt file
