### PR TITLE
Purple Reign level bump

### DIFF
--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -1739,7 +1739,7 @@ loc_data_table = {
     "Challenge Loot: I Like My Treasure Rare":                             BL2ArchiData("Menu", 6, tags=["general"]),
     "Challenge Loot: It's Not Easy Looting Green":                         BL2ArchiData("Menu", 6, tags=["general"]),
     "Challenge Loot: Nothing Rhymes with Orange":                          BL2ArchiData("Menu", 3, tags=["general"]),
-    "Challenge Loot: Purple Reign":                                        BL2ArchiData("Menu", 6, tags=["general"]),
+    "Challenge Loot: Purple Reign":                                        BL2ArchiData("Menu", 7, tags=["general"]),
     "Challenge Loot: Another Man's Treasure":                              BL2ArchiData("Menu", 6, tags=["general"]),
     "Challenge Recovery: This Is No Time for Lazy!":                       BL2ArchiData("Menu", 1, coop_type=1, tags=["general"]),
     "Challenge Recovery: Heal Plz":                                        BL2ArchiData("Menu", 6, tags=["general"]),


### PR DESCRIPTION
Bumping level requirement for Purple Reign to level 7, so as to require leaving Southern Shelf before it's considered in logic (Southern Shelf does not appear to spawn purple rarity loot whatsoever).