### PR TITLE
Missable unique shield updated

### DIFF
--- a/worlds/borderlands2/archi_defs.py
+++ b/worlds/borderlands2/archi_defs.py
@@ -74,7 +74,7 @@ gear_data_table = {
     # "Pearlescent Shield":             BL2ArchiData("", 0, tags=["gear"]),
     "Unique Shield":                    BL2ArchiData("Menu", 0, tags=["from_license", "gear"], item_kind=progression, req_items=["License: Unique Shield"], alternates=[
                                             BL2ArchiData("HuntersGrotto", 30, other_req_regions=["ScyllasGrove"]),
-                                            BL2ArchiData("BloodshotStronghold", 12, other_req_regions=["BloodshotRamparts", "FriendshipGulag"], tags=["from_quest_reward"]),
+                                            BL2ArchiData("BloodshotStronghold", 12, other_req_regions=["BloodshotRamparts", "FriendshipGulag"], tags=["from_quest_reward", "missable"]),
                                             BL2ArchiData("Highlands", 16, tags=["from_quest_reward"]),
                                             BL2ArchiData("HolySpirits", 16, tags=["from_quest_reward"]),
                                             BL2ArchiData("Sanctuary", 26, other_req_regions=["ControlCoreAngel"], tags=["from_quest_reward"]),


### PR DESCRIPTION
The 1340 shield is a quest reward, but one of two possible rewards for that quest.  If the Shotgun 1340 is chosen instead, the 1340 shield becomes permanently unobtainable as a quest reward.  Missable tag added to account for this.