### PR TITLE
Update chat command processing to be case insensitive

### DIFF
--- a/sdk_mods/BouncyLootGod/__init__.py
+++ b/sdk_mods/BouncyLootGod/__init__.py
@@ -1555,7 +1555,7 @@ def can_upgrade_skill(obj: unreal.UObject, args: unreal.WrappedStruct, ret, func
 
 @hook("WillowGame.TextChatGFxMovie:AddChatMessage")
 def add_chat_message(obj: unreal.UObject, args: unreal.WrappedStruct, ret, func: unreal.BoundFunction):
-    msg = args.msg[0:2].lower() + args.msg[2:]
+    msg = args.msg.lower()
     if msg.startswith("/travel") or msg.startswith("travel"):
         travel_arg = msg.replace(":", "").split("travel ")[-1].strip()
         map_name = get_translated_map_name(travel_arg)

--- a/sdk_mods/BouncyLootGod/bl2/entrances.py
+++ b/sdk_mods/BouncyLootGod/bl2/entrances.py
@@ -382,6 +382,7 @@ region_translation_dict = {
     "wildlife":                        "Wildlife Exploitation Preserve",
     "preserve":                        "Wildlife Exploitation Preserve",
     "wildlifepreserve":                "Wildlife Exploitation Preserve",
+    "wep":                             "Wildlife Exploitation Preserve",
     "terramorphouspeak":               "Terramorphous Peak",
     "terramorphous":                   "Terramorphous Peak",
     "terra":                           "Terramorphous Peak",


### PR DESCRIPTION
I have no context into why this was the way it was. But I'd like `TRAVEL` to work ok. I don't have a local dev setup to test this with, but I can set that up if you want me to.

You can ping me in ap after dark on the username `shiftweave` if you need anything changed or have feedback. I will also reply here.